### PR TITLE
docker-compose: relabel volumes for SELinux compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
                ./manage.py migrate &&
                ./manage.py runserver 0.0.0.0:8000"
     volumes:
-      - ./:/code
+      - ./:/code:z
     ports:
       - "8000:8000"
     depends_on:
@@ -45,6 +45,6 @@ services:
     build: ./
     command: "mkdocs serve"
     volumes:
-      - ./:/code
+      - ./:/code:z
     ports:
       - "8001:8001"


### PR DESCRIPTION
On Linux hosts with SELinux enabled access to volumes may be denied:

  api_1  | python: can't open file 'wait_for_postgres.py': [Errno 13] Permission denied

Tell docker-compose to relabel volumes so the container has permission
to access them. See
https://docs.docker.com/engine/reference/run/#volume-shared-filesystems.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>