### PR TITLE
gh-pages: publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,22 @@
+name: gh-pages
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate documentation HTML
+        run: python3 -m venv . && bin/pip install mkdocs && bin/mkdocs build
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The following link in README.md is currently 404:

  http://federationoftech.github.io/coalesce/

Add a GitHub Actions workflow that runs "mkdocs build" and publishes
GitHub Pages. This way the documentation HTML is rebuilt each time a
commit is merged on master.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>
---
Note that you need to enable GitHub Pages in Settings and use the default "gh-pages" branch name in order for this to work.