### PR TITLE
Add examples of docker-compose commands in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,39 @@ To start the dev server for local development:
 docker-compose up
 ```
 
-Run a command inside the docker container:
+Once everything is running, you should be able to see:
+
+ - the api server at [http://localhost:8000/](http://localhost:8000/),
+ - the frontend at [http://localhost:8080/](http://localhost:8080/),
+ - the documentation at [http://localhost:8001/](http://localhost:8001/).
+
+Run a command inside the api backend docker container:
 
 ```bash
-docker-compose run --rm web [command]
+docker-compose exec api [command]
 ```
+
+For example, `[command]` can be `/bin/bash` and you get a shell to the running container.
+
+Once you are in the container, you can then run the tests by doing:
+
+```bash
+./manage.py test
+```
+
+You can also start the django shell by doing:
+
+```bash
+./manage.py shell
+```
+
+To connect to the postgresql database, you can either do:
+
+```bash
+docker-compose exec postgres psql -U postgres
+```
+
+or connect to `localhost` on port `5432` using a local postgresql client.
 
 # Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,42 @@ Start the dev server for local development:
 docker-compose up
 ```
 
+Once everything is running, you should be able to see:
+
+ - the api server at [http://localhost:8000/](http://localhost:8000/),
+ - the frontend at [http://localhost:8080/](http://localhost:8080/),
+ - the documentation at [http://localhost:8001/](http://localhost:8001/).
+
 Create a superuser to login to the admin:
 
 ```bash
-docker-compose run --rm web ./manage.py createsuperuser
+docker-compose exec api ./manage.py createsuperuser
 ```
+
+Run a command inside the api backend docker container:
+
+```bash
+docker-compose exec api [command]
+```
+
+For example, `[command]` can be `/bin/bash` and you get a shell to the running container.
+
+Once you are in the container, you can then run the tests by doing:
+
+```bash
+./manage.py test
+```
+
+You can also start the django shell by doing:
+
+```bash
+./manage.py shell
+```
+
+To connect to the postgresql database, you can either do:
+
+```bash
+docker-compose exec postgres psql -U postgres
+```
+
+or connect to `localhost` on port `5432` using a local postgresql client.


### PR DESCRIPTION
Fix README and docs typo "web" service and change it to "api" instead.

Change `docker-compose run` to `docker-compose exec` to run commands in
the running container started using `docker-compose up`.

Add list of links for services started.

Add command for running psql in the postgres container.