### PR TITLE
Use DATABASE_URL instead of POSTGRES_* in docker-compose.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,12 +10,12 @@ jobs:
     container: python:3.8
 
     services:
-      postgres:
+      db:
         image: postgres:latest
         env:
-          POSTGRES_DB: postgres
+          POSTGRES_DB: test
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: password
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -37,6 +37,4 @@ jobs:
         run: ./manage.py test
         env:
           DJANGO_SECRET_KEY: local
-          POSTGRES_DB: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          DATABASE_URL: postgresql://postgres:password@db/test

--- a/coalesce/config/common.py
+++ b/coalesce/config/common.py
@@ -55,6 +55,7 @@ class Common(Configuration):
 
     # Postgres
     DATABASES = {
+        # Can be overridden using DATABASE_URL
         'default': dj_database_url.config(
             default='postgres://postgres:postgres@postgres:5432/postgres',
             conn_max_age=int(os.getenv('POSTGRES_CONN_MAX_AGE', 600))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
     restart: always
     environment:
       - DJANGO_SECRET_KEY=local
-      - POSTGRES_DB=postgres
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
+      - DATABASE_URL=postgresql://postgres:postgres@postgres/postgres
     image: api
     build: ./
     command: >


### PR DESCRIPTION
We had `POSTGRES_DB`, `POSTGRES_USER` and `POSTGRES_PASSWORD` in our
`docker-compose.yml` but they are not actually used in the code.
Instead we use the `dj_database_url` module, which takes a default url
but can be overridden by providing an environment variable called
`DATABASE_URL`.  I changed the test database host, password and database
name to show this works in the github test action.