### PR TITLE
Update link to Coalesce's github pages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ or connect to `localhost` on port `5432` using a local postgresql client.
 
 # Documentation
 
-Check out the project's [documentation](http://FederationOfTech.github.io/coalesce/).
+Check out the project's [documentation](https://FederationOfTech.github.io/Coalesce/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/FederationOfTech/coalesce.svg?branch=master)](https://travis-ci.org/FederationOfTech/coalesce)
 [![Built with](https://img.shields.io/badge/Built_with-Cookiecutter_Django_Rest-F7B633.svg)](https://github.com/agconti/cookiecutter-django-rest)
 
-An open source volunteer management platform. Check out the project's [documentation](http://FederationOfTech.github.io/coalesce/).
+An open source volunteer management platform. Check out the project's [documentation](https://FederationOfTech.github.io/Coalesce/).
 
 # Prerequisites
 


### PR DESCRIPTION
The original link is 404 because "/coalesce" is case sensitive and needs
to be changed to "/Coalesce".