### PR TITLE
Fix DATABASE_URL usage in wait_for_postgres.py

### DIFF
--- a/wait_for_postgres.py
+++ b/wait_for_postgres.py
@@ -2,14 +2,20 @@ import os
 import logging
 from time import time, sleep
 import psycopg2
+import dj_database_url
+
 check_timeout = os.getenv("POSTGRES_CHECK_TIMEOUT", 30)
 check_interval = os.getenv("POSTGRES_CHECK_INTERVAL", 1)
 interval_unit = "second" if check_interval == 1 else "seconds"
+
+# Get the database connection details from DATBASE_URL
+django_db_config = dj_database_url.config()
+
 config = {
-    "dbname": os.getenv("POSTGRES_DB", "postgres"),
-    "user": os.getenv("POSTGRES_USER", "postgres"),
-    "password": os.getenv("POSTGRES_PASSWORD", "postgres"),
-    "host": os.getenv("DATABASE_URL", "postgres")
+    "dbname": django_db_config.get("NAME", "postgres"),
+    "user": django_db_config.get("USER", "postgres"),
+    "password": django_db_config.get("PASSWORD", "postgres"),
+    "host": django_db_config.get("HOST", "postgres")
 }
 
 start_time = time()


### PR DESCRIPTION
The Django site uses dj_database_url to provide the database connection
details in a DATABASE_URL environment variable instead of multiple
environment variables for the host, user, password, etc.

Use dj_database_url instead of the old environment variables that are
unused. This fixes a 30 second delay and bogus error message when
starting the api container.

Fixes: 3ed2783896d9b4f5a769154cff71314c008f9b39
Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>