### PR TITLE
Connect Opportunity Details Page to REST API

### DIFF
--- a/frontend/coalesce/src/pages/OpportunityDetailsPage.vue
+++ b/frontend/coalesce/src/pages/OpportunityDetailsPage.vue
@@ -27,13 +27,13 @@
               <q-card-section class="bg-primary text-white">
                 <div class="text-subtitle1 text-weight-bold
 ">Personnel needed</div>
-                <div class="text-body2">{{ opportunity.number_of_volenteers_needed }}</div>
+                <div class="text-body2">{{ opportunity.personnel_needed }}</div>
                 <div class="text-subtitle1 text-weight-bold
 ">Commitment</div>
-                <div class="text-body2">{{ opportunity.commitment }} hours</div>
+                <div class="text-body2">{{ opportunity.commitment_type }}</div>
                 <div class="text-subtitle1 text-weight-bold
-">Estimated completion date</div>
-                <div class="text-body2">{{ opportunity.completion_date }}</div>
+">Date</div>
+                <div class="text-body2">{{ new Date(opportunity.datetime).toLocaleString() }}</div>
                 <div class="text-subtitle1 text-weight-bold
 ">Location</div>
                 <div class="text-body2">{{ opportunity.location }}</div>
@@ -76,34 +76,41 @@
       </div>
     </div>
 
+    <q-inner-loading :showing="loading">
+      <q-spinner-gears size="50px" color="primary" />
+    </q-inner-loading>
   </q-page>
 </template>
 
 <script>
-const opportunity = {
-  id: 123,
-  date: '2020/12/25',
-  title: 'My opportunity 1',
-  description: 'Description of the opportunity',
-  accepting_applications: true,
-  preparing_onboarding: false,
-  skills_required: [
-    'skill1', 'skill2'
-  ],
-  organiser_photo: '',
-  number_of_volenteers_needed: 4,
-  commitment: 20,
-  completion_date: '2020/01/14',
-  location: 'virtual',
-  completed: false
-}
+// TODO The following fields are not yet available from the REST API:
+// - accepting_applications (bool)
+// - preparing_onboarding (bool)
+// - completed (bool)
 
 export default {
   name: 'OpportunityDetailsPage',
   data () {
     return {
-      opportunity: opportunity
+      loading: true,
+      opportunity: {}
     }
+  },
+
+  created () {
+    this.$axios.get('/api/v1/opportunities/' + this.$route.params.id + '/',
+      {
+        headers: {
+          Authorization: 'Bearer ' + this.$store.state.auth.jwt.access
+        }
+      })
+      .then(response => {
+        this.loading = false
+        this.opportunity = response.data
+      })
+      .catch(e => {
+        console.log(e)
+      })
   }
 }
 </script>

--- a/frontend/coalesce/src/store/auth/mutations.js
+++ b/frontend/coalesce/src/store/auth/mutations.js
@@ -1,5 +1,5 @@
 export function updateToken (state, newToken) {
-  localStorage.setItem('t', newToken)
+  localStorage.setItem('t', JSON.stringify(newToken))
   state.jwt = newToken
 }
 

--- a/frontend/coalesce/src/store/auth/state.js
+++ b/frontend/coalesce/src/store/auth/state.js
@@ -1,7 +1,7 @@
 export default function () {
   return {
     //
-    jwt: localStorage.getItem('t'),
+    jwt: JSON.parse(localStorage.getItem('t') || '{}'),
     endpoints: {
       obtainJWT: '/api/token/',
       refreshJWT: '/api/token/refresh/'


### PR DESCRIPTION
These patches fetch Opportunity objects from the REST API so that hardcoded data is no longer needed in OpportunityDetailsPage.vue.

This required sending an HTTP GET request with axios. I added the JWT access token to the request headers although the API server currently does not require it. In the future we can expect the API server to customize responses based on the logged in user or to prevent access entirely, so let's be sure to include the token.

I'm a Vue.js and Quasar newbie, so please let me know if there is a nicer way of doing this!