### PR TITLE
Security for Opportunities

### DIFF
--- a/coalesce/opportunities/test/test_views.py
+++ b/coalesce/opportunities/test/test_views.py
@@ -7,6 +7,7 @@ import factory
 from .factories import OpportunityFactory
 from ..models import Opportunity
 from ...organizers.test.factories import OrganizerFactory
+from ...users.test.factories import UserFactory
 
 
 class TestOpportunitiesListTestCase(APITestCase):
@@ -19,12 +20,19 @@ class TestOpportunitiesListTestCase(APITestCase):
         self.opportunity_data = factory.build(
             dict, FACTORY_CLASS=OpportunityFactory
         )
+        self.user = UserFactory()
+
+    def test_anonymous_post_request_fails(self):
+        response = self.client.post(self.url, {})
+        eq_(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_post_request_with_no_data_fails(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
         response = self.client.post(self.url, {})
         eq_(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_request_with_valid_data_succeeds(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.user.auth_token}')
         response = self.client.post(self.url, self.opportunity_data)
         eq_(response.status_code, status.HTTP_201_CREATED)
 
@@ -42,11 +50,30 @@ class TestOpportunityDetailTestCase(APITestCase):
         self.opportunity = OpportunityFactory()
         self.url = reverse('opportunity-detail', kwargs={'pk': self.opportunity.pk})
 
+        # Creata an organizer and add them to the opportunity
+        self.organizer = OrganizerFactory()
+        self.opportunity.organizers.add(self.organizer)
+
     def test_get_request_returns_a_given_opportunity(self):
         response = self.client.get(self.url)
         eq_(response.status_code, status.HTTP_200_OK)
 
-    def test_patch_request_updates_an_opportunity(self):
+    def test_unauthenticated_patch_request_forbidden(self):
+        new_title = "New title"
+        payload = {'title': new_title}
+        response = self.client.patch(self.url, payload)
+        eq_(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_wrong_user_patch_request_forbidden(self):
+        other_user = OrganizerFactory()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {other_user.user.auth_token}')
+        new_title = "New title"
+        payload = {'title': new_title}
+        response = self.client.patch(self.url, payload)
+        eq_(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authenticated_patch_request_updates_an_opportunity(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.organizer.user.auth_token}')
         new_title = "New title"
         payload = {'title': new_title}
         response = self.client.patch(self.url, payload)
@@ -55,14 +82,14 @@ class TestOpportunityDetailTestCase(APITestCase):
         opportunity = Opportunity.objects.get(pk=self.opportunity.id)
         eq_(opportunity.title, new_title)
 
-    def test_patch_request_updates_organizers(self):
-        # TODO implement security checks to prevent malicious clients from modifying organizers
-        organizer = OrganizerFactory()
-        payload = {'organizers': [organizer.pk]}
+    def test_authenticated_patch_request_updates_organizers(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.organizer.user.auth_token}')
+        new_organizer = OrganizerFactory()
+        payload = {'organizers': [new_organizer.pk]}
         response = self.client.patch(self.url, payload)
         eq_(response.status_code, status.HTTP_200_OK)
 
         opportunity = Opportunity.objects.get(pk=self.opportunity.id)
         organizers = opportunity.organizers.all()
         eq_(organizers.count(), 1)
-        eq_(str(organizers[0].pk), organizer.pk)
+        eq_(str(organizers[0].pk), new_organizer.pk)

--- a/coalesce/opportunities/views.py
+++ b/coalesce/opportunities/views.py
@@ -1,8 +1,30 @@
 from rest_framework import viewsets, mixins
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import BasePermission, SAFE_METHODS
 
 from .models import Opportunity
 from .serializers import OpportunitySerializer
+
+
+class OpportunityOwnerPermission(BasePermission):
+    """
+    Only allow users who appear in the object organizers list to submit PATCH requests
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # Read permissions are allowed to any request,
+        # so we'll always allow GET, HEAD or OPTIONS requests.
+        if request.method in SAFE_METHODS:
+            return True
+
+        # For updates, the user must be listed as an organizer of the opportunity
+        return request.user in [o.user for o in obj.organizers.all()]
+
+    def has_permission(self, request, view):
+        # To post a new object simply test if the user is authenticated
+        # TODO: Also verify that the user is an organizer
+        if request.method == 'POST':
+            return request.user.is_authenticated
+        return True
 
 
 class OpportunityViewSet(mixins.RetrieveModelMixin,
@@ -11,8 +33,8 @@ class OpportunityViewSet(mixins.RetrieveModelMixin,
                          mixins.ListModelMixin,
                          viewsets.GenericViewSet):
     """
-    Updates and retrieves opportunities.
+    Retrieves opportunities.
     """
     queryset = Opportunity.objects.all()
     serializer_class = OpportunitySerializer
-    permission_classes = (AllowAny,)
+    permission_classes = (OpportunityOwnerPermission,)


### PR DESCRIPTION
Changes so that only authenticated users can create opportunities and only listed organizers can update them.