### PR TITLE
Add /organizer dashboard page

### DIFF
--- a/frontend/coalesce/src/pages/OrganizerDashboardPage.vue
+++ b/frontend/coalesce/src/pages/OrganizerDashboardPage.vue
@@ -1,0 +1,101 @@
+<template>
+  <q-page>
+    <div class="row q-pt-lg">
+      <div class="col-8 q-pa-md">
+        <h1>My Dashboard</h1>
+        <p>Magni nulla doloremque cupiditate ratione placeat hic tenetur praesentium. Quidem harum dolores odit quae explicabo. Quo nihil dignissimos aut quasi. Qui dolorem eius nemo. Et ut eum aliquam fuga.</p>
+
+        <div class="row">
+          <q-input
+            label="Search current opportunities..."
+            rounded
+            outlined
+            class="col-grow"
+            v-model="filter"
+            debounce="500"
+            v-on:input="search"
+            type="text"
+            :loading="loading"
+          >
+            <template v-slot:append>
+              <q-icon name="search" />
+            </template>
+          </q-input>
+
+          <q-btn to="/opportunity" class="q-ma-md" color="primary" label="Create an opportunity" size="lg" />
+        </div>
+
+        <!-- search results list -->
+        <div class="col-md-6 q-pa-md">
+          <div class="text-h2">Opportunities</div>
+        </div>
+        <div class="row" >
+          <div class="col-md-6 q-pa-md" v-for="o in opportunities" v-bind:key="o.id">
+            <q-card class="opportunity-card card">
+              <q-card-section class="bg-primary text-white">
+                <div class="text-h6">{{ o.title }}</div>
+              </q-card-section>
+
+              <q-card-section>
+                <div class="text-h7 ellipsis-2-lines">{{ o.description }}</div>
+              </q-card-section>
+
+              <q-separator />
+
+              <q-card-actions align="left" class="text-blue">
+                <q-btn flat>Open</q-btn>
+              </q-card-actions>
+            </q-card>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </q-page>
+</template>
+
+<script>
+export default {
+  name: 'OrganizerDashboardPage',
+  data () {
+    return {
+      // The search input textbox value
+      filter: '',
+
+      // True while waiting for a REST API call
+      loading: true,
+
+      // Search results
+      opportunities: []
+    }
+  },
+
+  methods: {
+    search () {
+      this.loading = true
+
+      // TODO if this.filter != "", add it as a search parameter for full-text
+      // search of opportunities
+      this.$axios.get('/api/v1/opportunities/',
+        {
+          headers: {
+            Authorization: 'Bearer ' + this.$store.state.auth.jwt.access
+          }
+        })
+        .then(response => {
+          this.loading = false
+
+          // TODO pagination via response.data.next and previous fields
+          this.opportunities = response.data.results
+        })
+        .catch(e => {
+          console.log(e)
+        })
+    }
+  },
+
+  created () {
+    this.search()
+  }
+}
+</script>

--- a/frontend/coalesce/src/router/routes.js
+++ b/frontend/coalesce/src/router/routes.js
@@ -7,6 +7,7 @@ const routes = [
       { path: 'login', component: () => import('pages/LogIn.vue') },
       { path: 'opportunities', component: () => import('pages/OpportunitiesSearchPage.vue') },
       { path: 'opportunity/:id', component: () => import('pages/OpportunityDetailsPage.vue') },
+      { path: 'organizer', component: () => import('pages/OrganizerDashboardPage.vue') },
       { path: 'volunteer/:id', component: () => import('pages/VolunteerDetailPage.vue') },
       { path: '/create-organiser', component: () => import('pages/CreateOrganiser.vue') },
       { path: '', component: () => import('pages/Index.vue') }


### PR DESCRIPTION
Go to http://localhost:8080/#/organizer to see the organizer dashboard.
It serves two purposes:

1. Contains the "Create an opportunity" button, which links to
   /create-opportunity (this page has not been created yet).

2. Offers an Opportunity search box similar to the /opportunities search
   page, except oriented towards organizers instead of volunteers. The
   search results currently display all opportunities, but this can be
   fixed when #6 is merged.

   Pagination is also missing. Only the first page of results from the
   REST API is displayed.

This commit makes progress towards the design wireframe in #46.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>