### PR TITLE
Fix JWT authentication configuration

### DIFF
--- a/coalesce/config/common.py
+++ b/coalesce/config/common.py
@@ -204,5 +204,8 @@ class Common(Configuration):
         'DEFAULT_AUTHENTICATION_CLASSES': (
             'rest_framework.authentication.SessionAuthentication',
             'rest_framework.authentication.TokenAuthentication',
+            'rest_framework_simplejwt.authentication.JWTAuthentication',
         )
     }
+
+    CORS_ORIGIN_WHITELIST = ("localhost", "frontend")

--- a/coalesce/settings.py
+++ b/coalesce/settings.py
@@ -1,8 +1,0 @@
-REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
-    ),
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-}
-
-CORS_ORIGIN_WHITELIST = ("localhost", "frontend")


### PR DESCRIPTION
JWT authentication was being configured in coalesce/settings.py although
Coalesce uses the django-configurations package. Configuration should be
in coalesce/config/ instead.

This caused inconsistent behavior (maybe some modules imported
settings.py?) where JWT authentication worked some of the time but not
all of the time.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>